### PR TITLE
junit report added for backend unit test

### DIFF
--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -22,11 +22,6 @@ jobs:
         run: |
           cd frontend
           npm test
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        if: always()
-        with:
-          junit_files: "frontend/junit.xml"
       - name: Upload Test Report Artifect
         uses: actions/upload-artifact@v3
         if: always()
@@ -83,11 +78,6 @@ jobs:
         run: |
           cd backend
           npm test
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        if: always()
-        with:
-          junit_files: "backend/junit.xml"
       - name: Upload Artifect
         uses: actions/upload-artifact@v3
         if: always()
@@ -161,6 +151,27 @@ jobs:
             PR message: ${{ github.event.pull_request.title }}
             Repository: ${{ github.repository }}
             See changes: https://github.com/${{ github.repository }}/pull/${{github.event.number}}
+  publish-unit-test:
+    runs-on: ubuntu-latest
+    name: Publish Unit Test Result
+    needs: [frontend-review, backend-review, sql-review]
+    if: always()
+    steps:
+      - name: Download Frontend Unit Test Result
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend_test_report
+          path: frontend/junit.xml
+      - name: Download Backend Unit Test Result
+        uses: actions/download-artifact@v3
+        with:
+          name: backendend_test_report
+          path: frontend/junit.xml
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        if: always()
+        with:
+          junit_files: "**/junit.xml"
   sonarcloud:
     runs-on: ubuntu-latest
     name: SonarCloud
@@ -170,12 +181,12 @@ jobs:
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
-      - name: Download Frontend Coverage Test
+      - name: Download Frontend Coverage Test Result
         uses: actions/download-artifact@v3
         with:
           name: frontend_coverage
           path: frontend/coverage
-      - name: Download Backend Coverage Test
+      - name: Download Backend Coverage Test Result
         uses: actions/download-artifact@v3
         with:
           name: backend_coverage

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -172,6 +172,8 @@ jobs:
           ls
           ls frontend
           ls backend
+          cat frontend/junit.xml
+          cat backend/junit.xml
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -166,7 +166,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: backend_test_report
-          path: frontend/junit.xml
+          path: backend/junit.xml
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -172,6 +172,8 @@ jobs:
           ls
           ls frontend
           ls backend
+          ls frontend/junit.xml
+          ls backend/junit.xml
           cat frontend/junit.xml
           cat backend/junit.xml
       - name: Publish Test Results

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -157,6 +157,7 @@ jobs:
     needs: [frontend-review, backend-review, sql-review]
     if: always()
     steps:
+      - uses: actions/checkout@v3
       - name: Download Frontend Unit Test Result
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -167,7 +167,10 @@ jobs:
         with:
           name: backend_test_report
           path: backend/junit.xml
-      - run: ls
+      - run: |
+          ls
+          ls frontend
+          ls backend
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Download Backend Unit Test Result
         uses: actions/download-artifact@v3
         with:
-          name: backendend_test_report
+          name: backend_test_report
           path: frontend/junit.xml
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -168,12 +168,6 @@ jobs:
         with:
           name: backend_test_report
           path: backend
-      - run: |
-          ls
-          ls frontend
-          ls backend
-          cat frontend/junit.xml
-          cat backend/junit.xml
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -162,18 +162,16 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: frontend_test_report
-          path: frontend/junit.xml
+          path: frontend
       - name: Download Backend Unit Test Result
         uses: actions/download-artifact@v3
         with:
           name: backend_test_report
-          path: backend/junit.xml
+          path: backend
       - run: |
           ls
           ls frontend
           ls backend
-          ls frontend/junit.xml
-          ls backend/junit.xml
           cat frontend/junit.xml
           cat backend/junit.xml
       - name: Publish Test Results

--- a/.github/workflows/PR-review.yml
+++ b/.github/workflows/PR-review.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           name: backend_test_report
           path: backend/junit.xml
+      - run: ls
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,6 @@
-node_modules
-coverage
+# dependencies
+/node_modules
+
+# testing
+/coverage
+junit.xml

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "nodemon src/server.js",
     "devStart": "nodemon src/server.js",
-    "test": "jest --coverage --forceExit"
+    "test": "jest --coverage --coverage --reporters=default --reporters=jest-junit --forceExit"
   },
   "author": "",
   "license": "ISC",
@@ -15,6 +15,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "fetch-mock": "^9.11.0",
+    "jest-junit": "^15.0.0",
     "mysql": "^2.18.1",
     "mysql2": "^2.3.3",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
This PR is not part of an issue but is a bugfix as the original backend unit test workflows did not generate a junit.xml file which caused the results of the unit test to be unviewable on the GitHub page.

This PR also fixes the issue where triggering `EnricoMi/publish-unit-test-result-action/composite@v2` multiple times does not "group" up the unit tests together and causes overriding.