### PR TITLE
Added uses to sonarcloud job

### DIFF
--- a/.github/workflows/sonarcloud-main-review.yml
+++ b/.github/workflows/sonarcloud-main-review.yml
@@ -70,6 +70,7 @@ jobs:
           path: backend/coverage
   sonarcloud:
     runs-on: ubuntu-latest
+    needs: [frontend-review, backend-review]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Previous workflow fails as all jobs ran asynchronously. Just I have added the `uses` which makes the sonarcloud job run after the frontend and backend unit test jobs.