### PR TITLE
Changed path from /frontend to /backend

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=devops-assignment1-team1_ias
 sonar.organization=devops-assignment1-team1
 sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
 # sonar.tests="**/src/__tests__/**"
-sonar.exclusions="**/src/__tests__/**", "coverage/**", "frontend/src/routes/student/msg.js"
+sonar.exclusions="**/src/__tests__/**", "coverage/**", "backend/src/routes/student/msg.js"
 
 sonar.cpd.exclusions="backend/src/routes/student/POST.js", "backend/src/routes/company/POST.js"
 # This is the name and version displayed in the SonarCloud UI.


### PR DESCRIPTION
Some previous PR changed the sonarcloud exclusion path for the msg.js file from /backend to /frontend. This PR is just to fix it.